### PR TITLE
Fixed Auto rescaling after maually resizing window

### DIFF
--- a/frontend/src/components/contents/presentations/Editor.jsx
+++ b/frontend/src/components/contents/presentations/Editor.jsx
@@ -147,7 +147,7 @@ const Editor = ({
                 Editor
               </spna>
             </div>
-            <div className="form-control col-11 editor-code-wrapper">
+            <div id="codeMirrorEditor" className="form-control col-11 editor-code-wrapper">
               <CodeMirror
                 onClick={onClick}
                 value={command}

--- a/frontend/src/components/editor/presentations/CodeMirrorWrapper.jsx
+++ b/frontend/src/components/editor/presentations/CodeMirrorWrapper.jsx
@@ -99,10 +99,19 @@ const CodeMirrorWrapper = ({
       onChange={(editor) => {
         onChange(editor.getValue());
         const lineCount = editor.lineCount();
+        let draggedHeight;
+        let height;
         if (lineCount <= 1) {
           editor.setOption('lineNumberFormatter', () => '$');
         } else {
           editor.setOption('lineNumberFormatter', (number) => number);
+          draggedHeight = document.getElementById('codeMirrorEditor').style.height;
+          if (draggedHeight) {
+            [height] = draggedHeight.split('px');
+            if (height < (58 + 21 * lineCount)) {
+              document.getElementById('codeMirrorEditor').style.height = null;
+            }
+          }
         }
         return true;
       }}

--- a/frontend/src/static/style.css
+++ b/frontend/src/static/style.css
@@ -228,6 +228,7 @@ a[data-toggle="collapse"] {
     resize: vertical;
     overflow: auto;
     height:auto;
+    display: flex;
 }
 
 .editor-button-wrapper {


### PR DESCRIPTION
The auto re scaling of query editor was not working if user adjusted the height by dragging down the code-mirror.
So I fixed the issue by re-scaling the window according to the number of input lines in the query.

It will again auto re-size if the number of line exceeds the length of dragged height. 