### PR TITLE
Allow large data initialization from viewer app

### DIFF
--- a/backend/src/controllers/cypherController.js
+++ b/backend/src/controllers/cypherController.js
@@ -70,7 +70,7 @@ class CypherController {
                     return await transaction(q);
                 }));
                 await transaction('COMMIT');
-                res.status(204).end();                
+                res.status(204).end();
             } catch (e){
                 await transaction('ROLLBACK');
                 const details = e.toString();

--- a/backend/src/models/GraphCreator.js
+++ b/backend/src/models/GraphCreator.js
@@ -31,7 +31,8 @@ class GraphCreator {
     }
 
     async createNode(node, type, qbuild = new QueryBuilder({
-        graphName:this.graphName
+        graphName:this.graphName,
+        returnAs:'v'
     })){
         const CREATENODE = 
         `(:${type} ${toAgeProps(node)})`;
@@ -41,6 +42,7 @@ class GraphCreator {
         }
         
         qbuild.insertQuery(CREATENODE);
+        this.query.nodes.push(qbuild.getGeneratedQuery());
     }
     async createEdge(edge, type, qbuild = new QueryBuilder(
         {
@@ -74,7 +76,6 @@ class GraphCreator {
     async readData(file, type, resolve){
         Papa.parse(file, {
             complete: (res) => {
-                console.log(res);
                 res.errors.forEach((e)=>{
                     if (e.type === 'FieldMismatch'){
                         res.data.splice(e.row, 1);
@@ -90,10 +91,6 @@ class GraphCreator {
         });
     }
     async parseData(){
-        const nodeQueryBuilder = new QueryBuilder({
-            graphName:this.graphName,
-            returnAs:'v'
-        });
         this.createGraph(this.dropGraph);
 
         this.nodes = await Promise.all(this.nodefiles.map((node) => new Promise((resolve) => {
@@ -102,21 +99,19 @@ class GraphCreator {
         })));
         this.nodes.forEach((nodeFile)=>{
             nodeFile.data.forEach((n)=>{
-                this.createNode(n, nodeFile.type, nodeQueryBuilder);
+                this.createNode(n, nodeFile.type);
             });
         });
-        this.query.nodes.push(nodeQueryBuilder.getGeneratedQuery());
-        
         this.edges = await Promise.all(this.edgefiles.map((edge) => new Promise((resolve) => {
             this.createEdgeLabel(edge.originalname);
             this.readData(edge.buffer.toString('utf8'), edge.originalname, resolve);
         })));
+
         this.edges.forEach((edgeFile)=>{
             edgeFile.data.forEach((e)=>{
                 this.createEdge(e, edgeFile.type);
             });
         });
-        console.log(this.query);
         return this.query;
         
     }

--- a/backend/src/models/QueryBuilder.js
+++ b/backend/src/models/QueryBuilder.js
@@ -5,8 +5,8 @@ class QueryBuilder {
     constructor({graphName, returnAs='x'}={}){
         this._graphName = graphName;
         this.ends = {
-            start:`SELECT * FROM cypher('${this._graphName}', $$ `,
-            end:` $$) as (${returnAs} agtype)`
+            start:`SELECT * FROM cypher('${this._graphName}', $$`,
+            end:`$$) as (${returnAs} agtype);`
         };
         this.clause = '';
         this.middle = [];


### PR DESCRIPTION
Due to the nature of the query "SELECT * FROM cypher(..." pgsql throws error "target lists can have at most 1664 entries" for large number of node/edge CREATE.
Split queries for nodes into several individual queries within transaction to prevent error.