### PR TITLE
Update instruction to get into postgres shell from inside docker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,15 @@ Install latest **pm2** with :
 	|	``-d``|	Run container in background and print container ID|
 - To Get the running log of the docker container created - 
 `` docker logs --follow myPostgresDb``
-- To Get into postgreSQL Shell - <br>
-	First get into docker shell using -	
-		`` docker exec -it myPostgresDb bash`` 
-	<br>Then get into postgreSQL shell using - 
-		`` psql -U postgresUser postgresDB``
+- To Get into postgreSQL Shell (There are two ways this can be done) -
+	- First get into docker shell using -	`` docker exec -it myPostgresDb bash`` 
+	<br>Then get into postgreSQL shell using - `` psql -U postgresUser postgresDB``
+	
+	OR
+	
+	- Alternatively postgres shell can also be assessed directly (without getting into the docker shell) -
+		`` psql -U postgresUser -d postgresDB -p 5455 -h localhost``
+		and put in ``postgresPW`` when prompted for password.
 - After logging into postgreSQL shell follow the [Post-Installation](https://github.com/apache/age#post-installation) instruction to create a graph in the database.
 ### Connect Apache Age-Viewer to PostgreSQL Database
 **Initial Connection Layout**

--- a/README.md
+++ b/README.md
@@ -77,8 +77,11 @@ Install latest **pm2** with :
 	|	``-d``|	Run container in background and print container ID|
 - To Get the running log of the docker container created - 
 `` docker logs --follow myPostgresDb``
-- To Get into postgreSQL Shell - 
-`` docker exec -it myPostgresDb bash``
+- To Get into postgreSQL Shell - <br>
+	First get into docker shell using -	
+		`` docker exec -it myPostgresDb bash`` 
+	<br>Then get into postgreSQL shell using - 
+		`` psql -U postgresUser postgresDB``
 - After logging into postgreSQL shell follow the [Post-Installation](https://github.com/apache/age#post-installation) instruction to create a graph in the database.
 ### Connect Apache Age-Viewer to PostgreSQL Database
 **Initial Connection Layout**


### PR DESCRIPTION
I found that the instruction to get into the postgres shell inside docker incomplete. Actually, the first step is to get into the docker bash shell and then from there open the postgres shell. So, I've added that instruction in the correct order.