### PR TITLE
view new graph's metadata when initialized

### DIFF
--- a/frontend/src/components/initializer/presentation/GraphInitializer.jsx
+++ b/frontend/src/components/initializer/presentation/GraphInitializer.jsx
@@ -101,9 +101,10 @@ const InitGraphModal = ({ show, setShow }) => {
         } else {
           setShow(false);
           dispatch(addAlert('CreateGraphSuccess'));
-          getMetaData();
-          changeCurrentGraph({ name: graphName });
-          changeGraph(graphName);
+          dispatch(getMetaData()).then(() => {
+            dispatch(changeCurrentGraph({ name: graphName }));
+            dispatch(changeGraph({ graphName }));
+          });
         }
       })
       .catch((err) => {


### PR DESCRIPTION
Immediately view newly created graph's metadata and set as current graph

![demo117](https://user-images.githubusercontent.com/67288224/213022664-58639bee-282d-4386-ba72-08312b711dc5.gif)
