### PR TITLE
Defined supported node versions in package.json engines field.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "ag-viewer",
   "version": "0.0.1",
   "private": true,
+  "engines": {
+    "node": "^14.16.0"
+  },
   "scripts": {
     "setup": "npm install && npm-run-all setup-front setup-backend",
     "setup-front": "cd frontend && npm install",


### PR DESCRIPTION

### Earlier

- When we install AGE-Viewer on a version of node that is not supported we simply get errors on `npm run start` but not any **warning while installing** beforehand.

![image](https://user-images.githubusercontent.com/71930390/213764799-f82aafe4-b845-4186-a02e-4df5152486c0.png)
<hr />

### Now

- If we try to **install** using an incompatible version then a **warning** like this would be issued:

![image](https://user-images.githubusercontent.com/71930390/213771010-27286095-8180-4c4e-8317-1db8aed1081f.png)

- And if `engine-strict` flag is set to `true` then an **error** like this is generated:

![image](https://user-images.githubusercontent.com/71930390/213771041-6d4bbdd2-d834-4536-a39c-049bfa5d2aaf.png)


