### PR TITLE
Cancelling Query from query editor on double Click only

### DIFF
--- a/frontend/src/components/contents/presentations/Editor.jsx
+++ b/frontend/src/components/contents/presentations/Editor.jsx
@@ -173,7 +173,7 @@ const Editor = ({
                   size="lg"
                 />
               </button> */}
-              <button className={command ? 'btn show-eraser' : 'btn hide-eraser'} type="button" id="eraser" onClick={() => clearCommand()}>
+              <button className={command ? 'btn show-eraser' : 'btn hide-eraser'} type="button" id="eraser" onDoubleClick={() => clearCommand()}>
                 <FontAwesomeIcon
                   icon={faTimesCircle}
                   size="1x"


### PR DESCRIPTION
Cancelling query can done on mouse single click but now I changed it to double click for confirmation purpose. So that if we are sure so we can double click on cancel button.

[Screencast from 01-20-2023 02:04:07 PM.webm](https://user-images.githubusercontent.com/72203032/213787560-c7322040-f164-4529-967c-f85e88c239ca.webm)
Here is the working of implementation.