### PR TITLE
Updating graph list on the editor when a graph is created/dropped

### DIFF
--- a/frontend/src/components/contents/presentations/Editor.jsx
+++ b/frontend/src/components/contents/presentations/Editor.jsx
@@ -108,7 +108,8 @@ const Editor = ({
           }
           return;
         }
-        if (update) dispatch(getMetaData());
+        const graphsUpdate = response?.payload?.query?.toLowerCase().includes('create_graph') || response?.payload?.query?.toLowerCase().includes('drop_graph');
+        if (update || graphsUpdate) dispatch(getMetaData());
       });
       activePromises[refKey] = req;
       setPromises({ ...activePromises });


### PR DESCRIPTION
This pull request is related to the enhancement request on #131 
The feature is loading the graph into the graph list when a new graph is created or dropped ** consistency** .

Done through fetching the metadata when the response is fulfilled and contains a query with **create_graph** / **drop_graph** 
2 lines added exactly you can check them out on the changes

**Demo**
![Create/Drop graph demo](https://user-images.githubusercontent.com/39674365/228384192-b228f5d8-5a42-4244-a5f8-6d0bc8980c5b.gif)
