### PR TITLE
added required responsiveness

### DIFF
--- a/frontend/src/static/style.css
+++ b/frontend/src/static/style.css
@@ -385,17 +385,22 @@ a[data-toggle="collapse"] {
     
     .sidebar-body {
         display: flex;
-        width: 100%;
+        width: 80%;
     }
 
     .horizontalLine {
-        visibility: collapse;
+        display: none;
     }
 
     .sidebar-item-disconnect {
         display: flex;
-        width: 75%;
+        flex-direction: column;
+        width: 100%;
         margin: 0 auto;
+    }
+
+    .sidebar-item-disconnect-outer {
+        width: 20%;
     }
 
     .sidebar-item-disconnect-buttons {


### PR DESCRIPTION
## What does this PR do?

Fixes #134 

The graph dropdown and its enclosing div no longer break out of the outer div on smaller dimensions.

![responsive](https://user-images.githubusercontent.com/75930195/236641557-b3d16cd2-bdbc-4111-95a2-02ae8a2e6f68.gif)

## How should this be tested?

Check if the above shown behavior is consistent.