### PR TITLE
Slightly change in the frontend of main page of apache-age viewer

### DIFF
--- a/frontend/src/components/frame/Frame.jsx
+++ b/frontend/src/components/frame/Frame.jsx
@@ -85,6 +85,7 @@ const Frame = ({
             onClick={() => dispatch(setCommand(reqString))}
             style={{
               cursor: 'pointer',
+              marginLeft: '5px',
             }}
           />
         </div>


### PR DESCRIPTION
In the existing version icon of  "**copy to editor**" is nearly overlapping with text of  "**server connect**"  on the main page which look a little non professional. I noticed it while using apache age viewer so I decided why not change it and give it a little padding. 