### PR TITLE
Fix onClick function for FontAwesomeIcon component in Frame component

### DIFF
--- a/frontend/src/components/frame/Frame.jsx
+++ b/frontend/src/components/frame/Frame.jsx
@@ -82,7 +82,10 @@ const Frame = ({
             title="copy to editor"
             icon={faClone}
             size="s"
-            onClick={() => dispatch(setCommand(reqString))}
+            onClick={() => {
+              navigator.clipboard.writeText(reqString);
+              dispatch(setCommand(reqString));
+            }}
             style={{
               cursor: 'pointer',
             }}


### PR DESCRIPTION
This pull request fixes the onClick function for the FontAwesomeIcon component in the Frame React component. In the previous implementation, there was an unfinished onClick function that doesn't copy the text to the clipboard. it is a simple line added 