### PR TITLE
Fix Metadata Load Error in PG v13, v14 and v15

### DIFF
--- a/backend/sql/13/meta_data.sql
+++ b/backend/sql/13/meta_data.sql
@@ -1,0 +1,13 @@
+SELECT * FROM (
+        SELECT c.relname AS label, n.oid as namespace_id, c.reltuples AS cnt
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n
+        ON n.oid = c.relnamespace
+        WHERE c.relkind = 'r'
+        AND n.nspname = '%s'
+) as q1
+JOIN ag_graph as g ON q1.namespace_id = g.namespace
+INNER JOIN ag_label as label
+
+ON label.name = q1.label
+AND label.graph = g.graphid;

--- a/backend/sql/14/meta_data.sql
+++ b/backend/sql/14/meta_data.sql
@@ -1,0 +1,13 @@
+SELECT * FROM (
+        SELECT c.relname AS label, n.oid as namespace_id, c.reltuples AS cnt
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n
+        ON n.oid = c.relnamespace
+        WHERE c.relkind = 'r'
+        AND n.nspname = '%s'
+) as q1
+JOIN ag_graph as g ON q1.namespace_id = g.namespace
+INNER JOIN ag_label as label
+
+ON label.name = q1.label
+AND label.graph = g.graphid;

--- a/backend/sql/15/meta_data.sql
+++ b/backend/sql/15/meta_data.sql
@@ -1,0 +1,13 @@
+SELECT * FROM (
+        SELECT c.relname AS label, n.oid as namespace_id, c.reltuples AS cnt
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n
+        ON n.oid = c.relnamespace
+        WHERE c.relkind = 'r'
+        AND n.nspname = '%s'
+) as q1
+JOIN ag_graph as g ON q1.namespace_id = g.namespace
+INNER JOIN ag_label as label
+
+ON label.name = q1.label
+AND label.graph = g.graphid;


### PR DESCRIPTION
I had an issue with AGE Viewer showing the metadata of graphs on PostgreSQL 13, which I described [on StackOverflow](https://stackoverflow.com/questions/76840251/how-do-i-fix-metadata-load-error-in-age-viewer/76861841#76861841). 

While trying to debug the issue, I noticed that, for every version of PostgreSQL, there is a folder containing `meta_data.sql` to fetch the metadata. Then, I discovered that the folder was missing for v13. This pull request has the fix to this issue.

Update:
Since AGE's master branch currently supports PG15, I added folders containing `meta_data.sql` for v14 and v15.