### PR TITLE
remove redundant console.log

### DIFF
--- a/frontend/src/features/cypher/CypherUtil.js
+++ b/frontend/src/features/cypher/CypherUtil.js
@@ -396,7 +396,6 @@ export const generateCytoscapeElement = (data, maxDataOfGraph, isNew) => {
       });
     });
   }
-  console.log('edge sizes', edgeLabelSizes);
   return {
     legend: {
       nodeLegend: sortByKey(nodeLegend),


### PR DESCRIPTION
removing a redundant console.log that eventualy spams the console logs