### PR TITLE
Fix: Prevent Undefined nodes and edges in GraphCreator Initialization

### DIFF
--- a/backend/src/controllers/cypherController.js
+++ b/backend/src/controllers/cypherController.js
@@ -41,8 +41,8 @@ class CypherController {
             let [client, transaction] = await db.graphRepository.createTransaction();
             try {
                 let graph = new GraphCreator({
-                    nodes: req.files.nodes,
-                    edges: req.files.edges,
+                    nodes: req.files.nodes || [],
+                    edges: req.files.edges || [],
                     graphName: req.body.graphName,
                     dropGraph: req.body.dropGraph === 'true'
                 });


### PR DESCRIPTION
#### **Summary**  
This PR ensures that `nodes` and `edges` properties in `GraphCreator` are always initialized as arrays, preventing potential `undefined` errors when processing uploaded files.  

#### **Changes**  
- Updated `CypherController.js`:  
  - Set `nodes` and `edges` to default to empty arrays (`[]`) if `req.files.nodes` or `req.files.edges` are `undefined`.  

#### **Reason for Change**  
- If `req.files.nodes` or `req.files.edges` is missing, `GraphCreator` would receive `undefined`, potentially causing runtime errors during graph parsing.  
- Defaulting these values to empty arrays ensures that downstream operations, such as `map()` and `forEach()`, do not fail.  

#### **Impact**  
- Improves robustness when handling file uploads.  
- Prevents potential crashes due to missing properties.  
- Ensures `GraphCreator` always has valid `nodes` and `edges` arrays to work with.  